### PR TITLE
Use the `text` method to retrieve the text contents

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,12 +20,12 @@ module.exports = function getAPIKey (options, callback) {
 
     var $ = cheerio.load(body);
 
-    if ($('#mainContents h2').html() === 'Access Denied') {
+    if ($('#mainContents h2').text() === 'Access Denied') {
       return callback(new Error('Access Denied'));
     }
 
-    if ($('#bodyContents_ex h2').html() === 'Your Steam Web API Key') {
-      var key = $('#bodyContents_ex p').html().split(' ')[1];
+    if ($('#bodyContents_ex h2').text() === 'Your Steam Web API Key') {
+      var key = $('#bodyContents_ex p').text().split(' ')[1];
       return callback(null, key);
     }
 


### PR DESCRIPTION
I think it makes more sense to use the `.text()` method to retrieve the text contents of the element.
It might make also sense to trim the returned string. 
